### PR TITLE
Filter for matching ServiceTypeID when multiple bookings exist

### DIFF
--- a/src/Client/index.ts
+++ b/src/Client/index.ts
@@ -58,7 +58,9 @@ class TexasScheduler {
             LastFourDigitsSsn: this.config.personalInfo.lastFourSSN,
         };
 
-        const response: ExistBookingResponse[] = await this.requestApi('/api/Booking', 'POST', requestBody).then(res => res.body.json());
+        const response: ExistBookingResponse[] = await this.requestApi('/api/Booking', 'POST', requestBody)
+            .then(res => res.body.json())
+            .then((res: ExistBookingResponse[]) => res.filter((booking: ExistBookingResponse) => booking.ServiceTypeId == this.config.personalInfo.typeId));
         // if no booking found, the api will return empty array
         if (response.length > 0) return { exist: true, response };
         return { exist: false, response };

--- a/src/Interfaces/ExistBooking.ts
+++ b/src/Interfaces/ExistBooking.ts
@@ -10,4 +10,5 @@ export interface ExistBookingResponse {
     ConfirmationNumber: string;
     BookingDateTime: string;
     SiteName: string;
+    ServiceTypeId: number;
 }


### PR DESCRIPTION
Hi, thanks for the out-of-box solution that saves me hours! This on-the-fly change is to filter for matching serviceTypeID when multiple bookings exist. (e.g. John has an existing DL appointment & a Class C appointment and he wants to schedule for a new Class C appointment and cancel the existing one upon success)