### PR TITLE
Fix issue with rescheduling a booking

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "texas-dps-scheduler",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "Texas DPS Automatic Scheduler",
   "main": "dist/index.js",
   "scripts": {

--- a/src/Client/index.ts
+++ b/src/Client/index.ts
@@ -76,14 +76,12 @@ class TexasScheduler {
     }
 
     private async cancelBooking(ConfirmationNumber: string) {
-        const { response } = this.existBooking;
-        const { DateOfBirth, FirstName, LastName, Last4Ssn } = response[0];
         const requestBody: CancelBookingPayload = {
             ConfirmationNumber,
-            DateOfBirth,
-            LastFourDigitsSsn: Last4Ssn,
-            FirstName,
-            LastName,
+            DateOfBirth: this.config.personalInfo.dob,
+            LastFourDigitsSsn: this.config.personalInfo.lastFourSSN,
+            FirstName: this.config.personalInfo.firstName,
+            LastName: this.config.personalInfo.lastName,
         };
         await this.requestApi('/api/CancelBooking', 'POST', requestBody);
         log.info('Canceled booking successfully');


### PR DESCRIPTION
When rescheduling a booking, it would fail when attempting to cancel the previous reservation. This was due to the DOB and last four SSN not being set correctly. Maybe the response from the existing booking changed to no longer include that. Now using the values from the config to populate all variables for the cancel booking Post.