### PR TITLE
Force viewport to 1920x1080

### DIFF
--- a/src/Browser/index.ts
+++ b/src/Browser/index.ts
@@ -22,6 +22,7 @@ export const getAuthTokenFromBroswer = async (): Promise<string> => {
         const browser = await puppeteer.launch({
             headless: process.env.HEADLESS?.toLowerCase() == 'false' ? false : 'shell',
             slowMo: 10,
+            defaultViewport: { width:1920, height:1080 },
             args: ['--no-sandbox', '--disable-setuid-sandbox', '--disk-cache-size=0'],
             browser: 'chrome',
             executablePath: executablePath(),


### PR DESCRIPTION
This forces the viewport size for Puppeteer to 1920x1080, which seems to help in certain cases where elements can't be clicked while trying to acquire a CAPTCHA token.